### PR TITLE
expose recoverPrivateKey

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,7 @@ const exportedProperties = [
   'listAccounts', 
   'newAccount',
   'importPrivateKey',
+  'recoverPrivateKey',
   'getBalance',
   'getNonce',
   'selectAccount',


### PR DESCRIPTION
This is so that you can create an account on Cardano, fund it, and then get access to it in something other than Mallet.